### PR TITLE
Component sidebars

### DIFF
--- a/api/src/main/java/net/megavex/scoreboardlibrary/api/animation/Animation.java
+++ b/api/src/main/java/net/megavex/scoreboardlibrary/api/animation/Animation.java
@@ -1,0 +1,14 @@
+package net.megavex.scoreboardlibrary.api.animation;
+
+import java.util.Collection;
+import org.jetbrains.annotations.NotNull;
+
+public interface Animation<T> {
+  static <T> @NotNull Animation<T> animation(@NotNull Collection<T> frames) {
+    return new CollectionAnimation<>(frames);
+  }
+
+  @NotNull T currentFrame();
+
+  void nextFrame();
+}

--- a/api/src/main/java/net/megavex/scoreboardlibrary/api/animation/CollectionAnimation.java
+++ b/api/src/main/java/net/megavex/scoreboardlibrary/api/animation/CollectionAnimation.java
@@ -1,0 +1,28 @@
+package net.megavex.scoreboardlibrary.api.animation;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collection;
+import java.util.List;
+import org.jetbrains.annotations.NotNull;
+
+class CollectionAnimation<T> implements Animation<T> {
+  private final List<T> frames;
+  private int currentFrameIndex;
+
+  CollectionAnimation(@NotNull Collection<T> frames) {
+    this.frames = ImmutableList.copyOf(frames);
+  }
+
+  @NotNull
+  @Override
+  public T currentFrame() {
+    return frames.get(currentFrameIndex);
+  }
+
+  @Override
+  public void nextFrame() {
+    if (++currentFrameIndex == frames.size()) {
+      currentFrameIndex = 0;
+    }
+  }
+}

--- a/api/src/main/java/net/megavex/scoreboardlibrary/api/sidebar/component/ComponentSidebar.java
+++ b/api/src/main/java/net/megavex/scoreboardlibrary/api/sidebar/component/ComponentSidebar.java
@@ -1,0 +1,75 @@
+package net.megavex.scoreboardlibrary.api.sidebar.component;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.List;
+import net.kyori.adventure.text.Component;
+import net.megavex.scoreboardlibrary.api.sidebar.Sidebar;
+import org.jetbrains.annotations.NotNull;
+
+public class ComponentSidebar {
+  private final Sidebar sidebar;
+  private SidebarComponent titleComponent = drawable -> {
+  };
+  private final List<SidebarComponent> components = new ArrayList<>(4);
+
+  public ComponentSidebar(@NotNull Sidebar sidebar) {
+    this.sidebar = sidebar;
+  }
+
+  public @NotNull Sidebar sidebar() {
+    return sidebar;
+  }
+
+  public @NotNull SidebarComponent titleComponent() {
+    return titleComponent;
+  }
+
+  public void titleComponent(@NotNull SidebarComponent titleComponent) {
+    Preconditions.checkNotNull(titleComponent);
+    this.titleComponent = titleComponent;
+  }
+
+  public void addComponent(@NotNull SidebarComponent component) {
+    components.add(component);
+  }
+
+  public void updateLines() {
+    titleComponent.draw(new SidebarTitleDrawable());
+
+    var lines = new SidebarLineDrawable();
+    for (var component : components) {
+      component.draw(lines);
+    }
+    lines.clearRemainingLines();
+  }
+
+  private class SidebarTitleDrawable implements LineDrawable {
+    private boolean isFirst = false;
+
+    @Override
+    public void drawLine(@NotNull Component line) {
+      if (isFirst) {
+        sidebar.title(line);
+        isFirst = false;
+      }
+    }
+  }
+
+  private class SidebarLineDrawable implements LineDrawable {
+    private int index = 0;
+
+    @Override
+    public void drawLine(@NotNull Component line) {
+      if (index < Sidebar.MAX_LINES) {
+        sidebar.line(index++, line);
+      }
+    }
+
+    private void clearRemainingLines() {
+      for (int i = index; i < Sidebar.MAX_LINES; i++) {
+        sidebar.line(i, null);
+      }
+    }
+  }
+}

--- a/api/src/main/java/net/megavex/scoreboardlibrary/api/sidebar/component/LineDrawable.java
+++ b/api/src/main/java/net/megavex/scoreboardlibrary/api/sidebar/component/LineDrawable.java
@@ -1,0 +1,16 @@
+package net.megavex.scoreboardlibrary.api.sidebar.component;
+
+import net.kyori.adventure.text.Component;
+import org.jetbrains.annotations.NotNull;
+
+/**
+ * Something lines can be drawn to
+ */
+public interface LineDrawable {
+  /**
+   * Draws a line, or does nothing if has reached the end
+   *
+   * @param line Line component
+   */
+  void drawLine(@NotNull Component line);
+}

--- a/api/src/main/java/net/megavex/scoreboardlibrary/api/sidebar/component/SidebarComponent.java
+++ b/api/src/main/java/net/megavex/scoreboardlibrary/api/sidebar/component/SidebarComponent.java
@@ -1,0 +1,32 @@
+package net.megavex.scoreboardlibrary.api.sidebar.component;
+
+import com.google.common.base.Preconditions;
+import net.kyori.adventure.text.Component;
+import net.megavex.scoreboardlibrary.api.animation.Animation;
+import org.jetbrains.annotations.NotNull;
+
+
+import static net.kyori.adventure.text.Component.empty;
+
+public interface SidebarComponent {
+  static @NotNull SidebarComponent staticLine(@NotNull Component line) {
+    Preconditions.checkNotNull(line);
+    return drawable -> drawable.drawLine(line);
+  }
+
+  static @NotNull SidebarComponent blankLine() {
+    return drawable -> drawable.drawLine(empty());
+  }
+
+  static @NotNull SidebarComponent animatedLine(@NotNull Animation<Component> animation) {
+    Preconditions.checkNotNull(animation);
+    return drawable -> drawable.drawLine(animation.currentFrame());
+  }
+
+  static @NotNull SidebarComponent animatedComponent(@NotNull Animation<SidebarComponent> animation) {
+    Preconditions.checkNotNull(animation);
+    return drawable -> animation.currentFrame().draw(drawable);
+  }
+
+  void draw(@NotNull LineDrawable drawable);
+}


### PR DESCRIPTION
Adds a new abstraction over the `Sidebar` interface called `ComponentSidebar`, which is more powerful than `AbstractSidebar` and the Kotlin DSL.

TODO:
- [ ] Unit tests
- [ ] New Kotlin DSL
- [ ] Update README
- [ ] Deprecate `AbstractSidebar` and the old sidebar Kotlin DSL