### PR TITLE
Support for adding custom packet adapter

### DIFF
--- a/implementation/src/main/java/net/megavex/scoreboardlibrary/implementation/ScoreboardLibraryImpl.java
+++ b/implementation/src/main/java/net/megavex/scoreboardlibrary/implementation/ScoreboardLibraryImpl.java
@@ -72,6 +72,36 @@ public class ScoreboardLibraryImpl implements ScoreboardLibrary {
     }
   }
 
+  public ScoreboardLibraryImpl(@NotNull Plugin plugin, @NotNull ScoreboardLibraryPacketAdapter<?> packetAdapter) {
+    Preconditions.checkNotNull(plugin, "plugin");
+    Preconditions.checkNotNull(packetAdapter, "packetAdapter");
+
+    try {
+      Class.forName("net.kyori.adventure.Adventure");
+    } catch (ClassNotFoundException e) {
+      throw new IllegalStateException("Adventure is not in the classpath");
+    }
+
+    this.plugin = plugin;
+    this.packetAdapter = packetAdapter;
+    this.localeProvider = this.packetAdapter.localeProvider;
+    this.taskScheduler = TaskScheduler.create(plugin);
+
+    boolean localeEventExists = false;
+    try {
+      Class.forName("org.bukkit.event.player.PlayerLocaleChangeEvent");
+      localeEventExists = true;
+    } catch (ClassNotFoundException ignored) {
+    }
+
+    if (localeEventExists) {
+      localeListener = new LocaleListener(this);
+      plugin.getServer().getPluginManager().registerEvents(localeListener, plugin);
+    } else {
+      localeListener = null;
+    }
+  }
+
   public @NotNull Plugin plugin() {
     return plugin;
   }


### PR DESCRIPTION
The use case scenario for this is like adding some other packet library based packet adapter. Eg: ProtocolLib

In my current situation, I have this setup:
```kotlin
implementation("com.github.megavexnetwork.scoreboard-library:scoreboard-library-implementation:${Dependencies.SCOREBOARD_LIBRARY}")
implementation("com.github.megavexnetwork.scoreboard-library:scoreboard-library-v1_20_R1:${Dependencies.SCOREBOARD_LIBRARY}")
```

The protocol version for the working server is 1_17_R1 and the adapter for 1.20 works fine until this version (I have already checked it). And, I am have a issue with `NoPacketAdapterAvailableException`.
![image](https://github.com/MegavexNetwork/scoreboard-library/assets/71663979/19474795-bf23-4737-9adc-f47204b3ff21)

This would not be the best way to implement this, but for my situation it would work as I can initialize it by:
```java
var scoreboardLibrary = new ScoreboardLibraryImpl(plugin, net.megavex.scoreboardlibrary.implementation.packetAdapter.v1_20_R1.PacketAdapterImpl());
```