### PR TITLE
Add `plugin.yaml` example to `INSTALLATION.md`

### DIFF
--- a/INSTALLATION.md
+++ b/INSTALLATION.md
@@ -99,3 +99,24 @@ like [Shadow](https://gradleup.com/shadow/).
 ```
 
 You will need to shade these dependencies and relocate them with [maven-shade-plugin](https://maven.apache.org/plugins/maven-shade-plugin/).
+
+## `plugin.yaml` (Paper)
+
+Alternatively you can add the dependencies to your `plugin.yaml`. Paper will then automatically load these dependencies at runtime, no shading required.
+
+Add this to your `plugin.yaml`
+
+```yaml
+libraries:
+  - net.megavex:scoreboard-library-api:2.4.4
+  - net.megavex:scoreboard-library-implementation:2.4.4
+  - net.megavex:scoreboard-library-modern:2.4.4 # replace with the API you want to use
+```
+
+You will still need to add the API to your dependencies, for example like this in gradle:
+
+```java
+dependencies {
+  implementation("net.megavex:scoreboard-library-api:2.4.4") // replace with latest version
+}
+```


### PR DESCRIPTION
Dependencies like this library can be added to the `plugin.yaml` file, and then the paper server will (down)load them at runtime. With this approach shading / relocation is not needed, as the server automatically handles everything.

I personally was unable to figure out how to get the shading to work, so this approach might be a bit easier for noobs like me.